### PR TITLE
Updated the envelope details to be major and minor.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@ description: "Governance for MedCom HL7 FHIR®© Messaging is the basic ruleset 
 show_downloads: false
 google_analytics:
 theme: jekyll-theme-minimal
-version: "Version 1.0.11"
+version: "Version 1.0.12"
 fhir_version: "FHIR®© R4"
 releasenote: https://github.com/medcomdk/MedCom-FHIR-Communication/releases
 thisurl: https://medcomdk.github.io/MedCom-FHIR-Communication/

--- a/docs/assets/documents/FHIRMessages_NetworkEnvelopes_DA.md
+++ b/docs/assets/documents/FHIRMessages_NetworkEnvelopes_DA.md
@@ -75,7 +75,7 @@ Konkret betyder ovenstående for MedComs FHIR\-meddelelser dette
 |Kuvert  |VANSenvelope          |
 |Format  |"HL7"                 |
 |Name    |"MCM:FDIS91#`<code>`" |
-|Version |"3.0.0"               |
+|Version |"5.0"               |
 
 Postfixværdier for Name vil være indenfor dette code udfaldsrum, som er taget fra: <a href="https://medcomfhir.dk/ig/terminology/ValueSet-medcom-careCommunication-categories.html" target="_blank">CareCommunications ValueSet for categories</a>
 

--- a/docs/assets/documents/FHIRMessages_NetworkEnvelopes_EN.md
+++ b/docs/assets/documents/FHIRMessages_NetworkEnvelopes_EN.md
@@ -76,7 +76,7 @@ Specifically, the above for MedCom's FHIR messages means this
 |**Envelope Receiver**  |VANSEnvelope                           |
 |**Format**             |"HL7"                                  |
 |**Name**               |"MCM:FDIS91#`<postfix value>`"         |
-|**Version**            |"4.0.0"                                |
+|**Version**            |"5.0"                                |
 
 Name **MUST** explicitly be taken from the following ValueSet:<a href="https://medcomfhir.dk/ig/terminology/CodeSystem-medcom-messaging-sorEdiSystem.html" target="_blank">CodeSystem-medcom-messaging-sorEdiSystem</a>
 


### PR DESCRIPTION
i have updated the envelope details to only support major and minor, meaning the patch level is removed, as it can change more often.

This is only done for Carecommunication and not for the other FHIR messaging standards.