### PR TITLE
updated info and corrected spelling errors

### DIFF
--- a/docs/assets/documents/030_Governance-for-Network-Layer.md
+++ b/docs/assets/documents/030_Governance-for-Network-Layer.md
@@ -11,11 +11,11 @@
 
 The Danish Healthcare Messaging Network is currently the VANS Network on which the overall shipment of a message is handled through Asynchronous Messaging.
 
-To be able to communicate over the VANS Network, both senders and receivers **SHALL** have a GLN number issued by the SOR. <a href="https://sundhedsdatastyrelsen.dk/da/rammer-og-retningslinjer/organisationsregistrering" target="_blank">Click her to open SOR </a>. The SOR is developed by The Danish Health Data Authority and therefore the informations in SOR are in Danish.
+To be able to communicate over the VANS Network, both senders and receivers **SHALL** have a GLN number issued by the SOR. <a href="https://sundhedsdatastyrelsen.dk/da/rammer-og-retningslinjer/organisationsregistrering" target="_blank">Click here to open SOR </a>. The SOR is developed by The Danish Health Data Authority and therefore the information in SOR are in Danish.
 
-To be able to communicate a specific MedCom FHIR message type both senders and receivers **SHALL** be registered in SOR with that messagetype and version.
+To be able to communicate a specific MedCom FHIR message type both senders and receivers **SHALL** be registered in SOR with that message type and version.
 
-The Sending EcoSystem **SHALL** validate the message before dispatching it. Validating a message **SHALL** include validating the correct use of the ValueSets and CodeSystems used in the message.
+The Sending Ecosystem **SHALL** validate the message before dispatching it. Validating a message **SHALL** include validating the correct use of the ValueSets and CodeSystems used in the message.
 
 ## 1 VANSEnvelope
 
@@ -23,11 +23,11 @@ The VANSEnvelope is developed to contain XML-based or other non-edifact message 
 
 MedCom FHIR Messages **SHALL** be enveloped in a VANSEnvelope whether they are shipped as "application/fhir+xml" or "application/fhir+json"
 
-* The enveloping of MedCom FHIR Messages **SHALL** follow the VANSEnvelope specification outlined in
-  * <a href="https://svn.medcom.dk/svn/releases/Standarder/Den%20gode%20VANSEnvelope/Dokumentation" target="_blank"> Click here to read VANSEnvelope specification</a>. Please be aware that the VANSEnvelope specification is in danish.
-* MedCom FHIR Messages **SHALL** follow the metadata specification outlined in both danish and english:
+* The envelopment of MedCom FHIR Messages **SHALL** follow the VANSEnvelope specification outlined in
+  * <a href="https://svn.medcom.dk/svn/releases/Standarder/Den%20gode%20VANSEnvelope/Dokumentation" target="_blank"> Click here to read VANSEnvelope specification</a>. Please be aware that the VANSEnvelope specification is in Danish.
+* MedCom FHIR Messages **SHALL** follow the metadata specification outlined in both Danish and English:
   * [English:Network Envelope](FHIRMessages_NetworkEnvelopes_EN.md)
-* VANSEnvelopes **SHALL** only contain one MedCom FHIR Messages
+* VANSEnvelopes **SHALL** only contain one MedCom FHIR Message.
 
 ## 2 Reliable Messaging using VANSEnvelope
 
@@ -36,9 +36,9 @@ VANSEnvelope is developed to support Reliable Messaging.
 VANSEnvelope containing FHIR Messages **SHALL** make use of this Reliable Messaging functionality.
 
 * The use of Reliable Messaging functionality when shipping MedCom FHIR Messages **SHALL** follow the VANSEnvelope specification outlined in
-  * <a href="https://svn.medcom.dk/svn/releases/Standarder/Den%20gode%20VANSEnvelope/Dokumentation" target="_blank"> Click here to read VANSEnvelope specification</a>. Please be aware that the VANSEnvelope specification is in danish.
+  * <a href="https://svn.medcom.dk/svn/releases/Standarder/Den%20gode%20VANSEnvelope/Dokumentation" target="_blank"> Click here to read VANSEnvelope specification</a>. Please be aware that the VANSEnvelope specification is in Danish.
 
-[Click here to see how to setup Reliable Messaging using VANSEnvelope](032_Reliable_Messaging-VANSEnvelope.md)
+[Click here to see how to set up Reliable Messaging using VANSEnvelope](032_Reliable_Messaging-VANSEnvelope.md)
 
 ## 3 Sending MedCom FHIR messages
 
@@ -46,11 +46,11 @@ Sending MedCom FHIR messages over the VANS Network requires the sending system t
 
 When sending to both primary and cc destinations.
 
-1. A Sending Ecosystem **MUST** secure that the MedCom FHIR messages for primary and cc receivers differs on ID's as described in [Governance for MedCom FHIR Messaging](040_Governance4FHIR-Messaging.md)
-2. A Sending Ecosystem **MUST** ensure that the size of a MedCom FHIR message embeded in a VANSEnvelope is above 100 MB when send on the VANS Network. If the validation of size is before embedment in a VANSEnvelope, it is allowed for the sending ecosystem to set a limit to 100 MB, e.g. 98 MB, to ensure room for the embedment in VANS-envelope.
+1. A Sending Ecosystem **MUST** secure that the MedCom FHIR messages for primary and cc receivers differ on ID's as described in [Governance for MedCom FHIR Messaging](040_Governance4FHIR-Messaging.md)
+2. A Sending Ecosystem MUST ensure that the total size of a MedCom FHIR message, once embedded in a VANSEnvelope, does not exceed 100 MB when sent on the VANS Network. If the size is validated before the message is embedded in a VANSEnvelope, the Sending Ecosystem MAY apply a slightly lower limit to reserve space for the VANSEnvelope overhead and thereby ensure compliance with the 100 MB maximum.
 
 ## 4 Receiving MedCom FHIR messages
 
 A Receiving Ecosystem **SHALL** be able to receive MedCom FHIR messages both as "application/fhir+xml" and "application/fhir+json"
 
-A Receiving Ecosystem **SHALL** be able to handle both primary and cc destinations and routing them to the right application
+A Receiving Ecosystem **SHALL** be able to handle both primary and cc destinations and route them to the right application.


### PR DESCRIPTION
1. Corrected this sentence: “A Sending Ecosystem MUST ensure that the size of a MedCom FHIR message embeded in a VANSEnvelope is above 100 MB when send on the VANS Network” to “A Sending Ecosystem MUST ensure that the size of a MedCom FHIR message embedded in a VANSEnvelope is below 100 MB when sent on the VANS Network”, as the first version was incorrect.

2. Corrected other spelling and grammatical errors.